### PR TITLE
chore: avoid misleading checklist on issue

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,6 +4,7 @@
 
 `(Selecciona con una "x" => [x])`
 
+```
 - [ ] **🔥 Ser el próximo speaker:** ¡Súper! No olvides leer nuestras recomendaciones
 - [ ] **💬 Proponer un tema:** Qué te gustaría y por qué
 - [ ] **👍 Sugerir una idea/proyecto a la comunidad:** ¡Vaya! ¿Qué hay que hacer?
@@ -11,5 +12,6 @@
 - [ ] **😎 Convertirme en organizador:** Explícanos por qué y cómo puedes aportar
 - [ ] **🤓 Resolver una duda técnica:** No olvides mencionar tanto detalle como sea posible 
 - [ ] **Otro**
+```
 
 ## Descripción

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,17 +1,15 @@
 <!--- Si vas a proponer una charla no olvides leer nuestras recomendaciones primero 😄: https://github.com/angular-medellin/meetup/blob/master/SPEAKERS.md -->
 
-# Me gustaría ...  
+# Me gustaría...
 
-`(Selecciona con una "x" => [x])`
+<!--- Selecciona con una "x" => [x] -->
 
-```
-- [ ] **🔥 Ser el próximo speaker:** ¡Súper! No olvides leer nuestras recomendaciones
-- [ ] **💬 Proponer un tema:** Qué te gustaría y por qué
-- [ ] **👍 Sugerir una idea/proyecto a la comunidad:** ¡Vaya! ¿Qué hay que hacer?
-- [ ] **👏 Dar mi retroalimentación:** ¡Gracias!, esto nos hace crecer
-- [ ] **😎 Convertirme en organizador:** Explícanos por qué y cómo puedes aportar
-- [ ] **🤓 Resolver una duda técnica:** No olvides mencionar tanto detalle como sea posible 
-- [ ] **Otro**
-```
+- [ ] 😎 Ser el próximo speaker
+- [ ] 😃 Proponer un tema 
+- [ ] 😋 Sugerir una idea/proyecto
+- [ ] 🤠 Convertirme en organizador
+- [ ] 🤕 Resolver una duda técnica
+- [ ] 🤡 Otro
 
 ## Descripción
+


### PR DESCRIPTION
The current issue template creates a checklist-type issue which is a bit misleading given that the issue itself is not representing a checklist but rather a user selection. See image below:

<img width="214" alt="screen shot 2017-06-17 at 2 20 42 pm" src="https://user-images.githubusercontent.com/3689856/27255661-9b94558a-5368-11e7-829a-c2bee1a5db33.png">

Having the checklist rendered as a code snippet will avoid this. PD: the proposed _fix_ is emoji compatible.